### PR TITLE
Fix for sticky footer

### DIFF
--- a/src/Affirmation.js
+++ b/src/Affirmation.js
@@ -35,11 +35,11 @@ class Affirmation extends React.Component {
   render() {
     const quote = this.state.quote;
     return (
-      <>
+      <div className="Affirmation">
         <blockquote className="quote">{quote.quote}</blockquote>
         <p className="author-citation">{quote.author}</p>
         <button onClick={this.handleClick}>Next Affirmation</button>
-      </>
+      </div>
     );
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,7 @@
+#root, .App {
+  height: 100%;
+}
+
 .App {
   text-align: center;
 }
@@ -8,6 +12,8 @@
 }
 
 .App-header {
+  height: 100%;
+  overflow-x: hidden;
   background-color: #f7eaea;
   min-height: 100vh;
   display: flex;
@@ -58,4 +64,8 @@ button:hover {
   color: #000;
   background-color: #fff;
   border-color: #e6e6e6;
+}
+
+.Affirmation {
+  flex: 1;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -9,8 +9,8 @@ class App extends React.Component {
   render() {
     return (
       <div className="App">
-        <header className="App-header">
-          <Header />
+        <header className="App-header" style={{display: 'flex', flexDirection: 'columns'}}>
+          <Header/>
           <Affirmation />
           <Footer />
         </header>

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,10 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+html, body {
+  height: 100vh;
+}
+
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;


### PR DESCRIPTION
Utilizes flexbox to keep the footer consistently snug at the bottom.

* Added explicit height of 100vh to body/html
* Added explicit height of 100% to parents of footer under body level
* Replaced React fragment in affirmation with a div to add flex grow
* Made Header component a flex container to stack the three items and give any left over space to the affirmation section. 

Fixes #7 