### PR TITLE
Preview on twitter cards

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,14 @@
     <meta property="og:image" content="%PUBLIC_URL%/app-screenshot.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+
+    <!-- Twitter metadata. See https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/markup -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:description" content="A random affirmation generator" />
+    <meta name="twitter:title" content="Affirmation Generator" />
+    <meta name="twitter:site" content="@waterproofheart" />
+    <meta name="twitter:image" content="%PUBLIC_URL%/app-screenshot.png" />
+    <meta name="twitter:creator" content="@waterproofheart" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
     <meta name="twitter:description" content="A random affirmation generator" />
     <meta name="twitter:title" content="Affirmation Generator" />
     <meta name="twitter:site" content="@waterproofheart" />
-    <meta name="twitter:image" content="%PUBLIC_URL%/app-screenshot.png" />
+    <meta name="twitter:image" content="https://www.affirmations.madewithtech.com/static/media/lady_on_phone.87ff1de0.svg" />
     <meta name="twitter:creator" content="@waterproofheart" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
     <meta name="twitter:description" content="A random affirmation generator" />
     <meta name="twitter:title" content="Affirmation Generator" />
     <meta name="twitter:site" content="@waterproofheart" />
-    <meta name="twitter:image" content="https://www.affirmations.madewithtech.com/static/media/lady_on_phone.87ff1de0.svg" />
+    <meta name="twitter:image" content="https://deploy-preview-58--affirmations.netlify.com/app-screenshot.png" />
     <meta name="twitter:creator" content="@waterproofheart" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
## Preview on twitter cards

Added metatags for generating a preview image when shares a tweet.
This resolves #57.

### Docs 📚
https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/markup

### Preview 🖼
You can check on https://cards-dev.twitter.com/validator with https://deploy-preview-58--affirmations.netlify.com/ URL 😉